### PR TITLE
Added MultiGraph

### DIFF
--- a/src/components/Atoms/MultiGraph.jsx
+++ b/src/components/Atoms/MultiGraph.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { HighchartsReact } from 'highcharts-react-official'
 import Highcharts from 'highcharts/highstock'
 import { useTranslations } from '../../context/TranslationsContext'
@@ -7,16 +7,18 @@ import { useTranslations } from '../../context/TranslationsContext'
 export const MultiGraph = ({ seriesData }) => {
     const { t } = useTranslations();
     
-    Highcharts.setOptions({
-        lang: {
-            months: [t('january'), t('february'), t('march'), t('april'), t('may'), t('june'), t('july'), t('august'), t('september'), t('october'), t('november'), t('december')],
-            shortMonths: [t('jan'), t('feb'), t('mar'), t('apr'), t('may'), t('jun'), t('jul'), t('aug'), t('sep'), t('oct'), t('nov'), t('dec')],
-            numericSymbols: undefined,
-        },
-        rangeSelector: {
-            selected: 2 //6 months
-        }
-    })
+    useEffect(() => {
+        Highcharts.setOptions({
+            lang: {
+                months: [t('january'), t('february'), t('march'), t('april'), t('may'), t('june'), t('july'), t('august'), t('september'), t('october'), t('november'), t('december')],
+                shortMonths: [t('jan'), t('feb'), t('mar'), t('apr'), t('may'), t('jun'), t('jul'), t('aug'), t('sep'), t('oct'), t('nov'), t('dec')],
+                numericSymbols: undefined,
+            },
+            rangeSelector: {
+                selected: 2 //6 months
+            }
+        })
+    }, [seriesData]);
 
     return (
         <HighchartsReact
@@ -90,7 +92,6 @@ export const MultiGraph = ({ seriesData }) => {
                 },
                 series: seriesData,
             }}
-
             constructorType={"stockChart"}
         />
     )

--- a/src/components/Atoms/MultiGraph.jsx
+++ b/src/components/Atoms/MultiGraph.jsx
@@ -1,0 +1,97 @@
+import React from 'react'
+import { HighchartsReact } from 'highcharts-react-official'
+import Highcharts from 'highcharts/highstock'
+import { useTranslations } from '../../context/TranslationsContext'
+
+
+export const MultiGraph = ({ seriesData }) => {
+    const { t } = useTranslations();
+    
+    Highcharts.setOptions({
+        lang: {
+            months: [t('january'), t('february'), t('march'), t('april'), t('may'), t('june'), t('july'), t('august'), t('september'), t('october'), t('november'), t('december')],
+            shortMonths: [t('jan'), t('feb'), t('mar'), t('apr'), t('may'), t('jun'), t('jul'), t('aug'), t('sep'), t('oct'), t('nov'), t('dec')],
+            numericSymbols: undefined,
+        },
+        rangeSelector: {
+            selected: 2 //6 months
+        }
+    })
+
+    return (
+        <HighchartsReact
+            highcharts={Highcharts}
+            options={{
+                styledMode: true,
+                // Better colors because the default colors don't have enough contrast on dark mode
+                colors: ['#058DC7', '#50B432', '#ED561B', '#24CBE5', '#64E572', '#FF9655', '#FFF263', '#6AF9C4'],
+                credits: false,
+                scrollbar: {
+                    enabled: false
+                },
+                yAxis: [{
+                    labels: {
+                        align: 'right',
+                        x: -3
+                    },
+                    title: {
+                        text: t('price')
+                    },
+                    height: '100%',
+                    lineWidth: 2,
+                    resize: {
+                        enabled: true
+                    }
+                }],
+                tooltip: {
+                    backgroundColor: "var(--background-color)",
+                    split: true,
+                    xDateFormat: '%Y-%m-%d',
+                    shared: true
+                },
+                rangeSelector: {
+                    buttons: [{
+                        type: 'month',
+                        count: 1,
+                        text: t('1m')
+                    }, {
+                        type: 'month',
+                        count: 3,
+                        text: t('3m')
+                    }, {
+                        type: 'month',
+                        count: 6,
+                        text: t('6m')
+                    }, {
+                        type: 'ytd',
+                        text: t('ytd')
+                    }, {
+                        type: 'year',
+                        count: 1,
+                        text: t('1y')
+                    }, {
+                        type: 'all',
+                        text: t('all')
+                    }],
+                },
+                plotOptions: {
+                    area: {
+                        stacking: 'percentage',
+                        lineColor: '#666666',
+                        lineWidth: 1,
+                        marker: {
+                            lineWidth: 1,
+                            lineColor: '#666666'
+                        }
+                    },
+                    series: {
+                        turboThreshold: 0,
+                    }
+                },
+                series: seriesData,
+            }}
+
+            constructorType={"stockChart"}
+        />
+    )
+}

--- a/src/components/Atoms/index.js
+++ b/src/components/Atoms/index.js
@@ -10,5 +10,6 @@ import { Search } from "./Search";
 import { Table } from "./Table";
 import { Toast } from "./Toast";
 import { Typography } from "./Typography";
+import { MultiGraph } from "./MultiGraph";
 
-export { Table, Typography, Card, Button, Toast, Search, Badge, Modal, Breadcrumbs, ListGroup, ListItem, Pagination, Adsense };
+export { MultiGraph, Table, Typography, Card, Button, Toast, Search, Badge, Modal, Breadcrumbs, ListGroup, ListItem, Pagination, Adsense };

--- a/src/components/Market/MultiGraphItemList.jsx
+++ b/src/components/Market/MultiGraphItemList.jsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { Link } from 'gatsby'
+import { Stack } from 'react-bootstrap'
+import { isMobile, isTablet } from 'react-device-detect'
+import { Button, Table as DesktopTable, Typography } from '../../components/Atoms'
+import { Table as SrTable, Tbody as SrTbody, Th as SrTh, Thead as SrThead, Td as SrTd, Tr as SrTr } from 'react-super-responsive-table'
+import 'react-super-responsive-table/dist/SuperResponsiveTableStyle.css'
+import { TbTrash } from 'react-icons/tb'
+import { useTranslations } from '../../context/TranslationsContext'
+import { ItemImage } from '../../components/Items/ItemImage'
+import { ItemPrices } from '../../components/Items/ItemPrices'
+
+export const MultiGraphItemList = ({ items, removeItem }) => {
+    const { t } = useTranslations()
+
+    const Table = isMobile && !isTablet ? SrTable : DesktopTable;
+    const Thead = isMobile && !isTablet ? SrThead : 'thead';
+    const Tbody = isMobile && !isTablet ? SrTbody : 'tbody';
+    const Th = isMobile && !isTablet ? SrTh : 'td';
+    const Tr = isMobile && !isTablet ? SrTr : 'tr';
+    const Td = isMobile ? SrTd : 'td';
+
+    return (
+        items.length
+            ?
+            <Table responsive={true} withBaseStyles={{ breakpoint: '920px' }} className='mt-2'>
+                <Thead>
+                    <Tr>
+                        <Th>{ t('Name') }</Th>
+                        <Th>{ t('Price and Supply') }</Th>
+                        <Th align='right'></Th>
+                    </Tr>
+                </Thead>
+                <Tbody>
+                    {
+                        items.map((item) => (
+                            <Tr key={item.apiId}>
+                                <Td component='th' scope='row' className='d-flex align-items-start border-0'>
+                                    <ItemImage className='me-1' id={item.id} />
+                                    &nbsp;
+                                    <Typography as={Link} to={`/items/${item.slug}`} style={{ color: 'var(--bs-info)' }}>{item.name}</Typography>
+                                </Td>
+                                <Td className='border-0'>
+                                    <ItemPrices i={item.apiId} />
+                                </Td>
+                                <Td align='right' className='border-0'>
+                                    <Stack direction='horizontal' gap={1} className='justify-content-end'>
+                                        <Button size='sm' variant='danger' onClick={() => removeItem(item.apiId)}><TbTrash /></Button>
+                                    </Stack>
+                                </Td>
+                            </Tr>
+                        ))
+                    }
+                </Tbody>
+            </Table>
+            :
+            <Typography className='mt-2'>No items have been selected yet.</Typography>
+    )
+}

--- a/src/components/Market/MultiGraphItemList.jsx
+++ b/src/components/Market/MultiGraphItemList.jsx
@@ -36,7 +36,7 @@ export const MultiGraphItemList = ({ items, removeItem }) => {
                         items.map((item) => (
                             <Tr key={item.apiId}>
                                 <Td component='th' scope='row' className='d-flex align-items-start border-0'>
-                                    <ItemImage className='me-1' id={item.id} />
+                                    <ItemImage className='me-1' category={item.category} id={item.id} />
                                     &nbsp;
                                     <Typography as={Link} to={`/items/${item.slug}`} style={{ color: 'var(--bs-info)' }}>{item.name}</Typography>
                                 </Td>

--- a/src/components/Tools/ToolsListing.jsx
+++ b/src/components/Tools/ToolsListing.jsx
@@ -35,7 +35,6 @@ const TOOLS = [
         label: 'Archetype Counter',
         url: '/tools/archetype-counter/',
         icon: ArchetypeIcon,
-        highlight: true
     }
 ]
 

--- a/src/components/Tools/ToolsMarket.jsx
+++ b/src/components/Tools/ToolsMarket.jsx
@@ -21,7 +21,12 @@ const TOOLS = [
         label: "Trade Ads",
         url: '/market/trade-ads',
         icon: TradeAdIcon,
-    }
+    },
+    {
+        label: 'Multi Graph',
+        url: '/market/multigraph',
+        icon: '/sprites/051.png',
+    },
 ]
 
 export const ToolsMarket = () => {

--- a/src/components/Tools/ToolsMarket.jsx
+++ b/src/components/Tools/ToolsMarket.jsx
@@ -26,6 +26,7 @@ const TOOLS = [
         label: 'Multi Graph',
         url: '/market/multigraph',
         icon: '/sprites/051.png',
+        highlight: true
     },
 ]
 

--- a/src/pages/market/multigraph.js
+++ b/src/pages/market/multigraph.js
@@ -28,6 +28,7 @@ const MultiGraphPage = ({ pageContext }) => {
 				apiId: itemInfo.i,
 				name: itemInfo.n[language],
 				slug: itemInfo.slug,
+				category: itemInfo.category,
 				data: res
 			}
 			setItems([...items, item]);

--- a/src/pages/market/multigraph.js
+++ b/src/pages/market/multigraph.js
@@ -1,0 +1,102 @@
+import React, { useState } from 'react'
+import { Button, Stack } from 'react-bootstrap'
+import { Card, Search, Typography, MultiGraph } from '../../components/Atoms'
+import 'react-super-responsive-table/dist/SuperResponsiveTableStyle.css'
+import { MultiGraphItemList } from '../../components/Market/MultiGraphItemList'
+import { Page } from '../../components/Page'
+import { PageTitle } from '../../components/PageTitle'
+import { Seo } from '../../components/SEO'
+import { useTranslations } from '../../context/TranslationsContext'
+import { useMarket } from '../../context/MarketContext'
+import { prices as PricesApi } from '../../utils/prices'
+
+
+const MultiGraphPage = ({ pageContext }) => {
+    const { language, t } = useTranslations();
+    const { toggleInvestmentsModal, removeFromInvestments, allItems } = useMarket();
+    const [items, setItems] = useState([]);
+	const [selectedItem, setSelectedItem] = useState('');
+
+    const updateItemList = (apiId) => {
+		if (items.some(item => item.apiId === apiId))
+			return; // Item already in array
+
+		let itemInfo = allItems.find(({ i }) => i == apiId);
+		PricesApi.getItem(itemInfo.i).then(res => {
+			let item = {
+				id: itemInfo._id,
+				apiId: itemInfo.i,
+				name: itemInfo.n[language],
+				slug: itemInfo.slug,
+				data: res
+			}
+			setItems([...items, item]);
+		});
+    }
+
+	const onAddItemClick = (e) => {
+		updateItemList(selectedItem);
+	}
+
+	const getSeriesData = () => {
+		let seriesData = [];
+		items.map((item) => {
+			seriesData.push({
+				name: item.name,
+				data: item.data
+			});
+		});
+		return seriesData;
+	}
+
+	const removeItem = (apiId) => {
+		setItems(items.filter(i => i.apiId !== apiId));
+	}
+
+	const PAGE_TITLE = 'Multi Item Graph';
+
+	return (
+		<Page breadcrumbs={pageContext.breadcrumb} label={PAGE_TITLE}>
+			<PageTitle>
+				<Typography as='h1' className='mb-0'>{ PAGE_TITLE }</Typography>
+			</PageTitle>
+			<Stack gap={2}>
+				<Card>
+					<Typography as='h2'>Item List</Typography>
+					<div className='d-flex flex-wrap align-items-center' style={{ gap: '0.3rem' }}>
+						<div style={{ flexGrow: '1' }}>
+							<Search
+								items={
+									allItems.map(({ i, n }) => {
+										return (
+											{
+												value: i,
+												label: n[language]
+											}
+										)
+									})
+								}
+								onChange={({ value }) => setSelectedItem(value)}
+							/>
+						</div>
+						<Button variant='info' onClick={onAddItemClick}>
+							Add Item
+						</Button>
+					</div>
+					
+					<MultiGraphItemList items={items} removeItem={removeItem} />
+				</Card>
+				<Card>
+					<Typography as='h2'>Market Graph</Typography>
+					<MultiGraph seriesData={getSeriesData()} />
+				</Card>
+			</Stack>
+		</Page>
+	)
+};
+
+export const Head = () => {
+  return <Seo title='Multi Graph' description='Compare multiple items on the GTL at the same time.'></Seo>
+}
+
+export default MultiGraphPage;

--- a/src/pages/market/multigraph.js
+++ b/src/pages/market/multigraph.js
@@ -12,7 +12,7 @@ import { prices as PricesApi } from '../../utils/prices'
 
 
 const MultiGraphPage = ({ pageContext }) => {
-    const { language, t } = useTranslations();
+    const { language } = useTranslations();
     const { toggleInvestmentsModal, removeFromInvestments, allItems } = useMarket();
     const [items, setItems] = useState([]);
 	const [selectedItem, setSelectedItem] = useState('');
@@ -21,7 +21,7 @@ const MultiGraphPage = ({ pageContext }) => {
 		if (items.some(item => item.apiId === apiId))
 			return; // Item already in array
 
-		let itemInfo = allItems.find(({ i }) => i == apiId);
+		let itemInfo = allItems.find(({ i }) => i === apiId);
 		PricesApi.getItem(itemInfo.i).then(res => {
 			let item = {
 				id: itemInfo._id,


### PR DESCRIPTION
This PR adds the `MultiGraph` component for viewing multiple GTL items on the same graph.

Changes:
- `MultiGraph` component
- New page at `/market/multigraph`
- `MultiGraphItemList` for MultiGraph item table
