### PR TITLE
Fixes MultiGraph price data bug

### DIFF
--- a/src/components/Market/MultiGraphItemList.jsx
+++ b/src/components/Market/MultiGraphItemList.jsx
@@ -10,7 +10,7 @@ import { useTranslations } from '../../context/TranslationsContext'
 import { ItemImage } from '../../components/Items/ItemImage'
 import { ItemPrices } from '../../components/Items/ItemPrices'
 
-export const MultiGraphItemList = ({ items, removeItem, toggleHideItem }) => {
+export const MultiGraphItemList = ({ items, removeItem, editItem }) => {
     const { t } = useTranslations()
 
     const Table = isMobile && !isTablet ? SrTable : DesktopTable;
@@ -45,7 +45,7 @@ export const MultiGraphItemList = ({ items, removeItem, toggleHideItem }) => {
                                 </Td>
                                 <Td align='right' className='border-0'>
                                     <Stack direction='horizontal' gap={1} className='justify-content-end'>
-                                        <Button size='md' variant='info' onClick={() => toggleHideItem(item.apiId)}>
+                                        <Button size='md' variant='info' onClick={() => editItem(item.apiId, { hidden: !item.hidden })}>
                                             {
                                                 item.hidden
                                                 ? <TbEyeOff />


### PR DESCRIPTION
In the previous commit, items that were added to the Multi Graph list were put in LocalStorage and never updated unless the user removed them from the list and re-added them. This PR fixes that and updates the prices of stored items when the page is loaded. This could be considered inefficient to fetch prices every time the page is loaded, but a complete caching overhaul should be done in a future, separate PR.