### PR TITLE
[BUG]: Pokédex region filter hides Pokémon with PokéMMO-specific encounters

### DIFF
--- a/src/components/Pokedex/PokemonList.jsx
+++ b/src/components/Pokedex/PokemonList.jsx
@@ -51,26 +51,32 @@ const filterPokedex = (filters, t) => {
             if (filters.region) {
                 // get the dex id for the region
                 const { kanto_dex, johto_dex, hoenn_dex, sinnoh_dex, unova_dex } = getPokeDexIDs(pokemon.id);
+                // check if the pokemon has a location entry for this region (covers PokéMMO-specific
+                // encounters for pokemon that have no regional dex number, e.g. Breloom in Sinnoh)
+                const hasLocationInRegion = pokemon.locations.some(
+                    loc => loc.region_name.toLowerCase() === filters.region.toLowerCase()
+                );
                 // if the pokemon doesn't have the dex id or 0, filter it out
+                // unless it has an actual encounter location in that region
                 switch(filters.region) {
                     case "kanto":
-                        if (!kanto_dex)
+                        if (!kanto_dex && !hasLocationInRegion)
                             return false;
                         break;
                     case "johto":
-                        if (!johto_dex)
+                        if (!johto_dex && !hasLocationInRegion)
                             return false;
                         break;
                     case "hoenn":
-                        if (!hoenn_dex)
+                        if (!hoenn_dex && !hasLocationInRegion)
                             return false;
                         break;
                     case "sinnoh":
-                        if (!sinnoh_dex)
+                        if (!sinnoh_dex && !hasLocationInRegion)
                             return false;
                         break;
                     case "unova":
-                        if (!unova_dex)
+                        if (!unova_dex && !hasLocationInRegion)
                             return false;
                         break;
                     default:


### PR DESCRIPTION
## Describe the bug

When filtering the Pokédex by region, Pokémon that have real wild encounters in that region (in `monster.json`) but a regional dex number of 0 (in `dex.json`) are incorrectly excluded from results.

For example, Breloom appears on Sinnoh Route 210 (Lure encounter) and Swalot on Sinnoh Route 212,  both visible on their individual Pokédex cards, but neither shows up when filtering by Sinnoh region.

## Expected behavior

Any Pokémon with a wild encounter location in the selected region should appear in the filtered results, regardless of whether it has a regional dex number.

## Actual behavior

Pokémon with `sinnoh_dex=0` (or any region dex=0) are dropped by the region filter before their locations are checked, making **27 Pokémon invisible in region searches**.

Full list of affected Pokémon:

| Pokémon | Affected Region | Location |
|---|---|---|
| Mareep | Kanto | Altering Cave |
| Aipom | Kanto | Altering Cave |
| Pineco | Kanto | Altering Cave |
| Stantler | Kanto | Altering Cave |
| Smeargle | Kanto | Altering Cave |
| Poochyena | Kanto | Altering Cave |
| Zigzagoon | Kanto | Altering Cave |
| Slakoth | Kanto | Altering Cave |
| Sableye | Kanto | Altering Cave |
| Mawile | Kanto | Altering Cave |
| Aron | Kanto | Altering Cave |
| Spinda | Kanto | Altering Cave |
| Shuppet | Kanto | Altering Cave |
| Duskull | Kanto | Altering Cave |
| Absol | Kanto | Altering Cave |
| Luvdisc | Kanto | Route 19 |
| Bagon | Kanto | Altering Cave |
| Breloom | Sinnoh | Route 210 |
| Swalot | Sinnoh | Route 212 |
| Gyarados | Unova | Dragonspiral Tower |
| Azumarill | Unova | Abundant Shrine |
| Yanma | Unova | Route 11 |
| Nosepass | Unova | Route 13 |
| Aggron | Unova | Giant Chasm |
| Grumpig | Unova | Route 14 |
| Vibrava | Unova | Dragonspiral Tower |
| Roserade | Unova | Route 12 |

## Steps to reproduce

1. Go to `/tools/pokedex`
2. Select **Region: Sinnoh**
3. Search for **Breloom**
4. No results shown despite Breloom's own card correctly showing Sinnoh Route 210 (Lure)

## Screenshots

<img width="1318" height="856" alt="image" src="https://github.com/user-attachments/assets/596cc36d-3ae8-41c5-8cbb-093721566ceb" />

<img width="1378" height="877" alt="image" src="https://github.com/user-attachments/assets/c63dc376-7fe9-4ea5-a6ce-08bbe12bf3eb" />

## Desktop or mobile?

Desktop

## Browser

Chrome (Chromium-based)

## Fix

One file changed: `src/components/Pokedex/PokemonList.jsx`

Before rejecting a Pokémon for having a regional dex number of 0, the filter now also checks if the Pokémon has an actual encounter location entry for that region in `monster.json`. If it does, it passes through, and the existing location loop already handles filtering by route/encounter type/rarity correctly.