### PR TITLE
[feat] Add evolutions tab to the Pokedex

### DIFF
--- a/src/components/Pokedex/PokemonActionBar.jsx
+++ b/src/components/Pokedex/PokemonActionBar.jsx
@@ -1,12 +1,11 @@
 import React from 'react'
-import { TbBow, TbChartBar, TbLocation, TbPokeball } from 'react-icons/tb'
+import {TbArrowUpRight, TbBow, TbChartBar, TbLocation, TbPokeball} from 'react-icons/tb'
 import { usePokedex } from '../../context/PokedexContext'
 import { ActionToggler } from './ActionToggler'
-import { useTheme } from '@emotion/react'
 import { useTranslations } from '../../context/TranslationsContext'
 import { isMobile, isTablet } from 'react-device-detect'
 
-export const PokemonActionBar = ({ locationList, active, onClick }) => {
+export const PokemonActionBar = ({ locationList, active, onClick, evolutions }) => {
     const { TABS } = usePokedex()
     const { t } = useTranslations()
     return (
@@ -15,7 +14,7 @@ export const PokemonActionBar = ({ locationList, active, onClick }) => {
                 {
                     locationList.length
                         ? <ActionToggler
-                            active={active === TABS.LOCATION ? true : false}
+                            active={active === TABS.LOCATION}
                             onClick={() => onClick(TABS.LOCATION)}
                             icon={<TbLocation />}
                             title={
@@ -29,7 +28,7 @@ export const PokemonActionBar = ({ locationList, active, onClick }) => {
                         : false
                 }
                 <ActionToggler
-                    active={active === TABS.MOVES ? true : false}
+                    active={active === TABS.MOVES}
                     onClick={() => onClick(TABS.MOVES)}
                     icon={<TbBow />}
                     title={
@@ -41,7 +40,7 @@ export const PokemonActionBar = ({ locationList, active, onClick }) => {
                     }
                 />
                 <ActionToggler
-                    active={active === TABS.CATCH_RATE ? true : false}
+                    active={active === TABS.CATCH_RATE}
                     onClick={() => onClick(TABS.CATCH_RATE)}
                     icon={<TbPokeball />}
                     title={
@@ -53,7 +52,7 @@ export const PokemonActionBar = ({ locationList, active, onClick }) => {
                     }
                 />
                 <ActionToggler
-                    active={active === TABS.STATS ? true : false}
+                    active={active === TABS.STATS}
                     onClick={() => onClick(TABS.STATS)}
                     icon={<TbChartBar />}
                     title={
@@ -64,6 +63,22 @@ export const PokemonActionBar = ({ locationList, active, onClick }) => {
                             false
                     }
                 />
+                {
+                    evolutions.length
+                        ? <ActionToggler
+                            active={active === TABS.EVOLUTIONS}
+                            onClick={() => onClick(TABS.EVOLUTIONS)}
+                            icon={<TbArrowUpRight />}
+                            title={
+                                !isMobile || isTablet
+                                    ?
+                                    t('evolutions')
+                                    :
+                                    false
+                            }
+                        />
+                        : false
+                }
             </>
         </div>
 

--- a/src/components/Pokedex/PokemonEvolutions.jsx
+++ b/src/components/Pokedex/PokemonEvolutions.jsx
@@ -1,0 +1,123 @@
+import React from 'react'
+import {useTranslations} from '../../context/TranslationsContext'
+import {getMove, getPokemon} from "../../utils/pokemon"
+import {Button, Image} from "react-bootstrap"
+import {TbChevronRight} from "react-icons/tb"
+import {Badge, Card, Typography} from "../Atoms"
+import {Divider, Stack} from "@mui/material";
+import {getItemName} from "../../utils/items";
+import {useMarket} from "../../context/MarketContext";
+import {Link} from "gatsby";
+import {slugify} from "../../utils/slugify";
+
+export const PokemonEvolutions = ({evolutions}) => {
+    const { t, language } = useTranslations();
+    const { allItems } = useMarket();
+
+    const renderItem = (val) => {
+        const item = allItems.find(({ item_id }) => item_id === val)
+        const { _id, n } = item
+        return (
+            <Button as={Link} to={`/items/${slugify(n.en)}`} variant="link" size="sm" className='p-0' key={_id}>
+                <Stack direction="horizontal" gap={1}>
+                    <Image src={`/item/${_id}.png`} />
+                    <Typography as={Link}>{getItemName(item.item_id)[language]}</Typography>
+                </Stack>
+            </Button>
+        )
+    }
+
+    const renderMethod = (type, val) => {
+        if (type.startsWith('LEVEL_LOCATION_')) {
+            return (
+                <Stack direction="column" alignItems="center">
+                    <Typography as={"small"}>{t('when level up')}</Typography>
+                    <Typography as={"small"}>{t('near a')} {t(type)}</Typography>
+                </Stack>
+            )
+        }
+
+        switch (type) {
+            case 'LEVEL':
+                return <Typography as={"small"}>{t('Level')} {val}</Typography>
+            case 'LEVEL_WITH_SKILL':
+                const move = getMove(val)
+                return (
+                    <Stack direction="column" alignItems="center">
+                        <Typography as="small">{t('with move')} {move.name}</Typography>
+                        <Typography as="small"></Typography>
+                        <Typography as="small">({t('when level up')})</Typography>
+                    </Stack>
+                )
+            case 'LEVEL_FEMALE':
+            case 'LEVEL_MALE':
+                return <Typography as={"small"}>{t('Level')} {val} ({type.endsWith('FEMALE') ? t('Female') : t('Male')})</Typography>
+            case 'LEVEL_WITH_MONSTER':
+                const monster = getPokemon(val);
+                return (
+                    <Stack direction="column" alignItems="center">
+                        <Typography as={"small"}>{t('when level up')}</Typography>
+                        <Typography as={"small"}>({t('with')} {t(monster.name)} {t('in team')})</Typography>
+                    </Stack>
+                )
+            case 'HAPPINESS':
+            case 'HAPPINESS_DAY':
+            case 'HAPPINESS_NIGHT':
+                return <Typography as={"small"}>{t('Happiness')} ({type.endsWith('DAY') ? t('Day') : type.endsWith('NIGHT') ? t('Night') : `${t('Day')}/${t('Night')}`})</Typography>
+            case 'TRADE':
+                return <Typography as={"small"}>{t('Trade')}</Typography>
+            case 'TRADE_WITH_ITEM':
+            case 'LEVEL_ITEM_DAY':
+            case 'LEVEL_ITEM_NIGHT':
+            case 'ITEM':
+                return (
+                    <Stack direction="column" alignItems="center" gap={1}>
+                        {renderItem(val)}
+                        {type === 'TRADE_WITH_ITEM' && <Typography as="small">({t('Trade')})</Typography>}
+                        {type.startsWith("LEVEL_ITEM_") && <Typography as="small">{t('when level up')} ({type.endsWith('DAY') ? t('Day') : type.endsWith('NIGHT') ? t('Night') : ''})</Typography>}
+                    </Stack>
+                )
+            default:
+                return <Typography as={"small"}>{type}</Typography>
+        }
+    }
+
+    const renderEvolution = (evolution) => {
+        const targetPokemon = getPokemon(evolution.id);
+        return (
+            <Stack direction="row"
+                   key={evolution.id}
+                   spacing={{ xs: 1, sm: 2 }}
+                   gap={2}
+                   divider={<Divider orientation="vertical" flexItem ><TbChevronRight /></Divider>}
+                   justifyContent="center"
+            >
+                <Card>
+                    <Stack direction="column" gap={1} alignItems="center" justifyContent="center">
+                        <Image src={`/sprites/${targetPokemon.id.toString().padStart(3, '0')}.png`}
+                               style={{maxWidth: '4rem'}}/>
+                        <Typography as="span">{targetPokemon.name}</Typography>
+                        {renderMethod(evolution.type, evolution.val)}
+                    </Stack>
+                </Card>
+                {targetPokemon.evolutions.map((evolution) => renderEvolution(evolution))}
+            </Stack>
+        )
+    }
+
+    return (
+        <>
+            <Stack
+                direction={evolutions.length > 1 ? "row" : "column"}
+                divider={<Divider orientation="vertical" flexItem ><Badge>or</Badge></Divider>}
+                spacing={{ xs: 1, sm: 2 }}
+                gap={2}
+                useFlexGap
+                justifyContent="center"
+                flexWrap="wrap"
+            >
+                {evolutions.map((evolution) => renderEvolution(evolution))}
+            </Stack>
+        </>
+    )
+}

--- a/src/components/Pokedex/PokemonItem.jsx
+++ b/src/components/Pokedex/PokemonItem.jsx
@@ -16,6 +16,7 @@ import { PokemonHeldItems } from './PokemonHeldItems';
 import { PokemonLocations } from './PokemonLocations';
 import { PokemonMoveset } from './PokemonMoveset';
 import { TypeList } from './TypeList';
+import {PokemonEvolutions} from "./PokemonEvolutions";
 
 export const PokemonSection = ({ children, show, title }) => {
     if (!show) return null;
@@ -99,21 +100,26 @@ export const PokemonItem = (pokemon) => {
                 </Stack>
             </Stack >
             <>
-                <PokemonSection show={itemActiveTab === TABS.LOCATION ? true : false} title={t("Locations")}>
+                <PokemonSection show={itemActiveTab === TABS.LOCATION} title={t("Locations")}>
                     <PokemonLocations dexID={id} locationList={locationList} />
                 </PokemonSection>
-                <PokemonSection show={itemActiveTab === TABS.MOVES ? true : false} title={t("Moveset")}>
+                <PokemonSection show={itemActiveTab === TABS.MOVES} title={t("Moveset")}>
                     <PokemonMoveset dexID={id} moves={pokemon.moves} />
                 </PokemonSection>
-                <PokemonSection show={itemActiveTab === TABS.CATCH_RATE ? true : false} title={t("Catch rates")}>
+                <PokemonSection show={itemActiveTab === TABS.CATCH_RATE} title={t("Catch rates")}>
                     <CatchResults
                         results={catchResults}
                     />
                 </PokemonSection>
                 <PokemonSection
-                    show={itemActiveTab === TABS.STATS ? true : false}
+                    show={itemActiveTab === TABS.STATS}
                     title={t("Stats")}>
                     <PokemonBaseStats hp={hp} atk={attack} def={defense} spatk={sp_attack} spdef={sp_defense} spe={speed} />
+                </PokemonSection>
+                <PokemonSection
+                    show={itemActiveTab === TABS.EVOLUTIONS}
+                    title={t("Evolutions")}>
+                    <PokemonEvolutions evolutions={pokemon.evolutions} />
                 </PokemonSection>
             </>
         </Card >

--- a/src/context/PokedexContext.jsx
+++ b/src/context/PokedexContext.jsx
@@ -15,7 +15,8 @@ const TABS = {
     LOCATION: 'location',
     CATCH_RATE: 'catchrate',
     STATS: 'stats',
-    MOVES: 'moves'
+    MOVES: 'moves',
+    EVOLUTIONS: 'evolutions'
 }
 
 const PokedexContext = createContext({

--- a/src/locales/en-BR/translation.json
+++ b/src/locales/en-BR/translation.json
@@ -713,5 +713,19 @@
     "track your investments here. view analytics, such as net worth and investment performance.": "Track your investments here. View analytics, such as net worth and investment performance.",
     "post your trade ad, or view other players' trade deals. contact them in-game to discuss the deals.": "Post your trade ad, or view other players' trade deals. Contact them in-game to discuss the deals.",
     "overlays mutliple item graphs. analyse market trends of multiple items at once.": "Overlays mutliple item graphs. Analyse market trends of multiple items at once.",
-    "market prices, tools, and helpful information for pokemmo": "Market prices, tools, and helpful information for PokeMMO"
+    "market prices, tools, and helpful information for pokemmo": "Market prices, tools, and helpful information for PokeMMO",
+    "evolutions": "Evolutions",
+    "happiness": "Happiness",
+    "day": "Day",
+    "night": "Night",
+    "trade": "Trade",
+    "or": "or",
+    "with move": "With move",
+    "when level up": "When level up",
+    "with": "With",
+    "in team": "in team",
+    "near a": "Near a",
+    "level_location_1": "special magnetic field",
+    "level_location_2": "Moss Rock",
+    "level_location_3": "Ice Rock"
 }

--- a/src/locales/fr-FR/translation.json
+++ b/src/locales/fr-FR/translation.json
@@ -640,5 +640,19 @@
     "track your investments here. view analytics, such as net worth and investment performance.": "Suivez vos investissements ici. Consultez des analyses telles que la valeur nette et la performance des investissements.",
     "post your trade ad, or view other players' trade deals. contact them in-game to discuss the deals.": "Postez votre annonce d'échange ou consultez les offres d'échange d'autres joueurs. Contactez-les dans le jeu pour discuter des offres.",
     "overlays mutliple item graphs. analyse market trends of multiple items at once.": "Superposez plusieurs graphiques d'articles. Analysez les tendances du marché de plusieurs articles à la fois.",
-    "market prices, tools, and helpful information for pokemmo": "Prix ​​du marché, outils et informations utiles pour PokeMMO"
+    "market prices, tools, and helpful information for pokemmo": "Prix ​​du marché, outils et informations utiles pour PokeMMO",
+    "evolutions": "Évolutions",
+    "happiness": "Bonheur",
+    "day": "Jour",
+    "night": "Nuit",
+    "trade": "Échange",
+    "or": "ou",
+    "with move": "En connaissant l'attaque",
+    "when level up": "Gain de niveau",
+    "with": "Avec",
+    "in team": "dans l'équipe",
+    "near a": "Près d'un/d'une",
+    "LEVEL_LOCATION_1": "champ magnétique spécial",
+    "LEVEL_LOCATION_2": "Pierre Mousse",
+    "LEVEL_LOCATION_3": "Pierre Glacée"
 }


### PR DESCRIPTION
Just added a new tab in pokedex page to quickly find informations about evolutions of a pokemon
All needed data is already in monster.json

Some examples :
<img width="1298" height="360" alt="image" src="https://github.com/user-attachments/assets/ffb07d4d-3612-43e9-b1cb-2550ba31c350" />
<img width="1299" height="447" alt="image" src="https://github.com/user-attachments/assets/7557872f-12cb-41fe-ab34-58d8b2fa1c9e" />
<img width="1300" height="399" alt="image" src="https://github.com/user-attachments/assets/b60ee214-fc03-48fd-ab48-e90d1e19a568" />



